### PR TITLE
Docs: Description of Components/Flash width prop

### DIFF
--- a/design-site/docs/Components/Flash.mdx
+++ b/design-site/docs/Components/Flash.mdx
@@ -37,7 +37,7 @@ import { Table } from 'pipeline-ui';
   <tr><td>borderRadius</td><td>integer (optional)</td><td>1</td><td></td></tr>
   <tr><td>p</td><td>string (optional)</td><td>'3'</td><td></td></tr>
   <tr><td>variant</td><td>enum (optional)</td><td>'base'</td><td>Sets the colors of the background, text and links. Allowed values: 'base' 'success' 'warning' 'danger' 'info'.</td></tr>
-  <tr><td>width</td><td>string (optional)</td><td>'100%'</td><td>Sets theme.</td></tr>
+  <tr><td>width</td><td>string (optional)</td><td>'100%'</td><td>Sets the width.</td></tr>
     </tbody>
     </Table>
 


### PR DESCRIPTION
I doubt that the width parameter should set the theme and use "100%" as a default value for it