### PR TITLE
Documentation : Add byte limits about the 'note'

### DIFF
--- a/design-site/docs/AlgoComponents/AlgoSendButton.mdx
+++ b/design-site/docs/AlgoComponents/AlgoSendButton.mdx
@@ -95,7 +95,7 @@ import {Table} from 'pipeline-ui';
   <tr><td>index</td><td>integer</td><td>0</td><td>If Algorand, must be 0. If ASA, must be numeric index value</td></tr>
   <tr><td>recipient</td><td>string</td><td></td><td>Address of recipient</td></tr>
   <tr><td>amount</td><td>integer</td><td>1</td><td>amount to send in micro Algos</td></tr>
-  <tr><td>note</td><td>string</td><td>"note"</td><td></td></tr>
+  <tr><td>note</td><td>string</td><td>"note"</td><td>Any data up to 1000 bytes.</td></tr>
   <tr><td>wallet</td><td>reference</td><td></td><td>reference to an instance of Pipeline.init(); that is called ONCE when the app is initialized</td></tr>
   <tr><td>context</td><td>reference</td><td></td><td>Recommended value: this</td></tr>
   <tr><td>returnTo</td><td>string</td><td></td><td>string value of state key to return the transaction id</td></tr>


### PR DESCRIPTION
# About documentation
On the 'AlgoSendButton' documentation add byte limits about the 'note' field on the Algorand Transaction.
Check the official documentation here : https://developer.algorand.org/docs/reference/transactions/